### PR TITLE
Don't use the same color for `Special` as for strings

### DIFF
--- a/colors/hybrid.vim
+++ b/colors/hybrid.vim
@@ -366,7 +366,7 @@ exe "hi! Type"            .s:fg_orange      .s:bg_none        .s:fmt_none
 exe "hi! Structure"       .s:fg_aqua        .s:bg_none        .s:fmt_none
 "		Typedef"
 
-exe "hi! Special"         .s:fg_green       .s:bg_none        .s:fmt_none
+exe "hi! Special"         .s:fg_orange      .s:bg_none        .s:fmt_none
 "		SpecialChar"
 "		Tag"
 "		Delimiter"


### PR DESCRIPTION
Good for differentiating string interpolation markers like `%s`, consider this Python example.

Before:

![screen shot 2015-02-12 at 17 48 33](https://cloud.githubusercontent.com/assets/177685/6172202/864d0db0-b2df-11e4-8208-f7ee3e9cf1ec.png)

After:

![screen shot 2015-02-12 at 17 49 02](https://cloud.githubusercontent.com/assets/177685/6172210/8d67a8f8-b2df-11e4-838c-b75efbbc99e0.png)
