### PR TITLE
swap foreground with comment when using iTerm colors

### DIFF
--- a/colors/hybrid.vim
+++ b/colors/hybrid.vim
@@ -127,10 +127,12 @@ else
     let s:purple     = "13"   " LightMagenta
   elseif g:hybrid_use_iTerm_colors == 1
     let s:background = "NONE"
-    let s:foreground = "7"
+    "let s:foreground = "7"
+    let s:foreground = "15"
     let s:selection  = "0"
     let s:line       = "0"
-    let s:comment    = "15"
+    "let s:comment    = "15"
+    let s:comment    = "7"
     let s:red        = "1"
     let s:orange     = "11"
     let s:yellow     = "3"


### PR DESCRIPTION
Hi,

before swap:
![screen shot 2015-02-27 at 09 30 38](https://cloud.githubusercontent.com/assets/286635/6410075/57aaef6a-be63-11e4-9e95-168a1399d874.png)

after swap:
![screen shot 2015-02-27 at 09 29 23](https://cloud.githubusercontent.com/assets/286635/6410061/3596baf8-be63-11e4-91b4-798f35395f86.png)

Thanks for this scheme, it's really nice, :)
