### PR TITLE
BadSpell Changed

### DIFF
--- a/colors/hybrid.vim
+++ b/colors/hybrid.vim
@@ -294,7 +294,7 @@ exe "hi! Search"        .s:fg_background  .s:bg_yellow      .s:fmt_none
 exe "hi! SpecialKey"    .s:fg_selection   .s:bg_none        .s:fmt_none
 exe "hi! SpellCap"      .s:fg_blue        .s:bg_darkblue    .s:fmt_undr
 exe "hi! SpellLocal"    .s:fg_aqua        .s:bg_darkcyan    .s:fmt_undr
-exe "hi! SpellBad"      .s:fg_red         .s:bg_darkred     .s:fmt_undr
+exe "hi! SpellBad"      .s:fg_none        .s:bg_none       .s:fmt_undr
 exe "hi! SpellRare"     .s:fg_purple      .s:bg_darkpurple  .s:fmt_undr
 exe "hi! StatusLine"    .s:fg_comment     .s:bg_background  .s:fmt_revr
 exe "hi! StatusLineNC"  .s:fg_window      .s:bg_comment     .s:fmt_revr


### PR DESCRIPTION
Since vim is no expert on recognizing where to check spell and where not to. Giving a red color to the badSpell makes more confusion. So I propose to simple let it underlined ;)
